### PR TITLE
Fix `Property.init(unsafeObservable:)` bug that doesn't emit value when `property` is deallocated

### DIFF
--- a/Sources/RxProperty/RxProperty.swift
+++ b/Sources/RxProperty/RxProperty.swift
@@ -22,7 +22,6 @@ public final class Property<Element> {
     public typealias E = Element
 
     private let _behaviorRelay: BehaviorRelay<E>
-    private let _disposeBag: DisposeBag?
 
     /// Gets current value.
     public var value: E {
@@ -34,13 +33,11 @@ public final class Property<Element> {
     /// Initializes with initial value.
     public init(_ value: E) {
         _behaviorRelay = BehaviorRelay(value: value)
-        _disposeBag = nil
     }
 
     /// Initializes with `BehaviorRelay`.
     public init(_ behaviorRelay: BehaviorRelay<E>) {
         _behaviorRelay = behaviorRelay
-        _disposeBag = nil
     }
 
     /// Initializes with `Variable` (DEPRECATED).
@@ -82,14 +79,11 @@ public final class Property<Element> {
 
     /// Initializes with `initial` element and then `observable`.
     public init(initial: E, then observable: Observable<E>) {
-        let disposeBag = DisposeBag()
-        _disposeBag = disposeBag
-
         _behaviorRelay = BehaviorRelay(value: initial)
 
-        observable
+        _ = observable
             .bind(to: _behaviorRelay)
-            .disposed(by: disposeBag)
+            // .disposed(by: disposeBag)    // Comment-Out: Don't dispose when `property` is deallocated
     }
 
     /// Observable that synchronously sends current element and then changed elements.

--- a/Tests/RxPropertyTests/RxPropertyTests.swift
+++ b/Tests/RxPropertyTests/RxPropertyTests.swift
@@ -84,6 +84,84 @@ final class RxPropertyTests: XCTestCase {
 
     }
 
+    // MARK: - initWithUnsafe
+
+    func test_initWithUnsafe_value() {
+
+        let relay = BehaviorRelay<Int>(value: 0)
+        let property = Property<Int>(unsafeObservable: relay.asObservable())
+
+        XCTAssertEqual(property.value, 0)
+
+        relay.accept(1)
+        XCTAssertEqual(property.value, 1)
+
+        relay.accept(2)
+        XCTAssertEqual(property.value, 2)
+
+    }
+
+    func test_initWithUnsafe_asObservable() {
+
+        let relay = BehaviorRelay<Int>(value: 0)
+        var property: Property<Int>! = .init(unsafeObservable: relay.asObservable())
+
+        var events = [Event<Int>]()
+
+        // `.asObservable()` test
+        _ = property.asObservable().subscribe { event in
+            events.append(event)
+        }
+
+        XCTAssertEqual(events, [.next(0)],
+                       "should observe initial value")
+
+        relay.accept(1)
+        XCTAssertEqual(events, [.next(0), .next(1)])
+
+        relay.accept(2)
+        XCTAssertEqual(events, [.next(0), .next(1), .next(2)])
+
+        property = nil
+        XCTAssertEqual(events, [.next(0), .next(1), .next(2)],
+                       "`.completed` should NOT be observed when `property` is deallocated")
+
+        relay.accept(3)
+        XCTAssertEqual(events, [Event<Int>.next(0), .next(1), .next(2), .next(3)],
+                       "`property`'s observable should still be alive even when `property` is deallocated.")
+
+    }
+
+    func test_initWithUnsafe_changed() {
+
+        let relay = BehaviorRelay<Int>(value: 0)
+        var property: Property<Int>! = .init(unsafeObservable: relay.asObservable())
+
+        var events = [Event<Int>]()
+
+        // `.changed` test
+        _ = property.changed.subscribe { event in
+            events.append(event)
+        }
+
+        XCTAssertEqual(events, [Event<Int>](),
+                       "should NOT observe initial value")
+
+        relay.accept(1)
+        XCTAssertEqual(events, [.next(1)])
+
+        relay.accept(2)
+        XCTAssertEqual(events, [.next(1), .next(2)])
+
+        property = nil
+        XCTAssertEqual(events, [.next(1), .next(2)])
+
+        relay.accept(3)
+        XCTAssertEqual(events, [Event<Int>.next(1), .next(2), .next(3)],
+                       "`property`'s observable should still be alive even when `property` is deallocated.")
+
+    }
+
 }
 
 // MARK: RxSwift.Event + Equatable

--- a/Tests/RxPropertyTests/RxPropertyTests.swift
+++ b/Tests/RxPropertyTests/RxPropertyTests.swift
@@ -127,7 +127,7 @@ final class RxPropertyTests: XCTestCase {
                        "`.completed` should NOT be observed when `property` is deallocated")
 
         relay.accept(3)
-        XCTAssertEqual(events, [Event<Int>.next(0), .next(1), .next(2), .next(3)],
+        XCTAssertEqual(events, [.next(0), .next(1), .next(2), .next(3)],
                        "`property`'s observable should still be alive even when `property` is deallocated.")
 
     }
@@ -157,7 +157,7 @@ final class RxPropertyTests: XCTestCase {
         XCTAssertEqual(events, [.next(1), .next(2)])
 
         relay.accept(3)
-        XCTAssertEqual(events, [Event<Int>.next(1), .next(2), .next(3)],
+        XCTAssertEqual(events, [.next(1), .next(2), .next(3)],
                        "`property`'s observable should still be alive even when `property` is deallocated.")
 
     }


### PR DESCRIPTION
Fixes #4 .

This PR fixes `Property.init(unsafeObservable:)` bug that doesn't emit value when `property` is deallocated.

### Test Case example

```diff
 func test_initWithUnsafe_asObservable() {
 
     let relay = BehaviorRelay<Int>(value: 0)
     var property: Property<Int>! = .init(unsafeObservable: relay.asObservable())
 
     var events = [Event<Int>]()
 
     // `.asObservable()` test
     _ = property.asObservable().subscribe { event in
         events.append(event)
     }
 
     XCTAssertEqual(events, [.next(0)],
                    "should observe initial value")
 
     relay.accept(1)
     XCTAssertEqual(events, [.next(0), .next(1)])
 
     relay.accept(2)
     XCTAssertEqual(events, [.next(0), .next(1), .next(2)])
 
     property = nil
     XCTAssertEqual(events, [.next(0), .next(1), .next(2)],
                    "`.completed` should NOT be observed when `property` is deallocated")
 
     relay.accept(3)
-    XCTAssertEqual(events, [.next(0), .next(1), .next(2)],
-                   "BUG: `.next(3)` should be received even when `property` is deallocated.")
+    XCTAssertEqual(events, [.next(0), .next(1), .next(2), .next(3)],
+                   "`property`'s observable should still be alive even when `property` is deallocated.")
 
 }
```
