### PR TITLE
add completesOnDeinit param to init

### DIFF
--- a/Sources/RxProperty/RxProperty.swift
+++ b/Sources/RxProperty/RxProperty.swift
@@ -22,6 +22,7 @@ public final class Property<Element> {
     public typealias E = Element
 
     private let _behaviorRelay: BehaviorRelay<E>
+    private let _disposeBag = DisposeBag()
 
     /// Gets current value.
     public var value: E {
@@ -78,12 +79,23 @@ public final class Property<Element> {
     }
 
     /// Initializes with `initial` element and then `observable`.
-    public init(initial: E, then observable: Observable<E>) {
+    /// If completesOnDeinit is true, then `observable` is completed when `property` is deallocated.
+    public init(initial: E, then observable: Observable<E>, completesOnDeinit: Bool = false) {
+
         _behaviorRelay = BehaviorRelay(value: initial)
 
-        _ = observable
-            .bind(to: _behaviorRelay)
-            // .disposed(by: disposeBag)    // Comment-Out: Don't dispose when `property` is deallocated
+        if completesOnDeinit {
+
+            observable
+                .bind(to: _behaviorRelay)
+                .disposed(by: _disposeBag)
+
+        } else {
+
+            _ = observable
+                .bind(to: _behaviorRelay)
+
+        }
     }
 
     /// Observable that synchronously sends current element and then changed elements.

--- a/Tests/RxPropertyTests/RxPropertyTests.swift
+++ b/Tests/RxPropertyTests/RxPropertyTests.swift
@@ -159,9 +159,46 @@ final class RxPropertyTests: XCTestCase {
         relay.accept(3)
         XCTAssertEqual(events, [.next(1), .next(2), .next(3)],
                        "`property`'s observable should still be alive even when `property` is deallocated.")
+    }
+
+    func test_completesOnDeinit_true() {
+
+        var disposed = false
+
+        // never completes
+        let never = Observable<Int>.never()
+            .do(onDispose: {
+                disposed = true
+            })
+
+        do {
+            let property: Property<Int> = .init(initial: 0, then: never, completesOnDeinit: true)
+
+            property.asObservable().subscribe().disposed(by: DisposeBag())
+        } // property is gone
+
+        XCTAssertTrue(disposed)
 
     }
 
+    func test_completesOnDeinit_false() {
+
+        var disposed = false
+
+        // never completes
+        let never = Observable<Int>.never()
+            .do(onDispose: {
+                disposed = true
+            })
+
+        do {
+            let property: Property<Int> = .init(initial: 0, then: never, completesOnDeinit: false)
+
+            property.asObservable().subscribe().disposed(by: DisposeBag())
+        } // property is gone
+
+        XCTAssertFalse(disposed)
+    }
 }
 
 // MARK: RxSwift.Event + Equatable


### PR DESCRIPTION
## Issue

If source (`then`) observable doesn't complete by itself, source observable would never be disposed and leak.

## Solution

Add `completesOnDeinit` parameter to the initializer. false by default.

## Concerns

Caller needs to know if `property` is retained (or not retained) by its user.

```swift
class PositionTracker {

    private let disposeBag = DisposeBag()

    init(position: Property<Int>) {
        // This subscription would immediately disposed by `completesOnDeinit` option.
        position.asObservable().subscribe().disposed(by: disposeBag)
    }
}

let tracker = PositionTracker(position: Property<Int>(initial: 0, then: neverCompletingObservable, completesOnDeinit: true))
```

Other option is to adding self-completing code to source observable, but it looks more ugly.

```swift
let dispose = PublishRelay<Void>()
let completingObservable = neverCompletingObservable.takeUntil(dispose.asObservable())
let tracker = PositionTracker(position: Property<Int>(initial: 0, then: completingObservable))

...

// cleanup source observable
dispose.accept(true)
```

Any other better idea to workaround this situation?