### PR TITLE
Replace RxCocoa with RxRelay

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "RxSwift",
-        "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
+        "repositoryURL": "https://github.com/ReactiveX/RxSwift",
         "state": {
           "branch": null,
-          "revision": "e8aa1d892a0d8a153a28b74cbad25be534926f49",
-          "version": "4.4.0"
+          "revision": "002d325b0bdee94e7882e1114af5ff4fe1e96afa",
+          "version": "5.1.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,24 +1,21 @@
-// swift-tools-version:4.2
-// The swift-tools-version declares the minimum version of Swift required to build this package.
+// swift-tools-version:5.2
+// Managed by ice
 
 import PackageDescription
 
 let package = Package(
     name: "RxProperty",
     products: [
-        .library(
-            name: "RxProperty",
-            targets: ["RxProperty"]),
+        .library(name: "RxProperty", targets: ["RxProperty"]),
     ],
     dependencies: [
-         .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "4.0.0"),
+        .package(url: "https://github.com/ReactiveX/RxSwift", from: "5.1.1"),
     ],
     targets: [
-        .target(
-            name: "RxProperty",
-            dependencies: ["RxSwift", "RxCocoa"]),
-        .testTarget(
-            name: "RxPropertyTests",
-            dependencies: ["RxProperty"]),
+        .target(name: "RxProperty", dependencies: [
+            "RxSwift",
+            .product(name: "RxRelay", package: "RxSwift"),
+        ]),
+        .testTarget(name: "RxPropertyTests", dependencies: ["RxProperty"]),
     ]
 )

--- a/Sources/RxProperty/RxProperty.swift
+++ b/Sources/RxProperty/RxProperty.swift
@@ -7,7 +7,7 @@
 //
 
 import RxSwift
-import RxCocoa
+import RxRelay
 
 /// A get-only `BehaviorRelay` that works similar to ReactiveSwift's `Property`.
 ///

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+import RxPropertyTests
+
+var tests = [XCTestCaseEntry]()
+tests += RxPropertyTests.allTests()
+XCTMain(tests)

--- a/Tests/RxPropertyTests/RxPropertyTests.swift
+++ b/Tests/RxPropertyTests/RxPropertyTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import RxSwift
-import RxCocoa
+import RxRelay
 @testable import RxProperty
 
 final class RxPropertyTests: XCTestCase {

--- a/Tests/RxPropertyTests/XCTestManifests.swift
+++ b/Tests/RxPropertyTests/XCTestManifests.swift
@@ -1,0 +1,9 @@
+import XCTest
+
+#if !os(macOS)
+public func allTests() -> [XCTestCaseEntry] {
+    return [
+        testCase(RxPropertyTests.allTests),
+    ]
+}
+#endif


### PR DESCRIPTION
To configure RxRelay dependency I needed to:

- [x] Re-create `Package.swift` to use latest Swift Version and SwiftPM.

`Package.swift` is generated using [jakeheis/Ice](https://github.com/jakeheis/Ice).

Also done following.

- [x] Configured tests for `swift test`
- [x] Update RxSwift `4.0.0+` -> `5.1.1+`

Confirmed both `swift test` and `Cmd + U` from Xcode succeeds.🙆‍♂️